### PR TITLE
Change Runner to Fix Deploy

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   github-pages:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: helaili/jekyll-action@2.0.1


### PR DESCRIPTION
The problem before they turned off git hub pages on the org was the action just sat waiting for a runner. Turns out `ubuntu-16.04` was deprecated.

**Reference** 
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/